### PR TITLE
Add subteams directory with one file per subteam

### DIFF
--- a/subteams/core.md
+++ b/subteams/core.md
@@ -1,0 +1,21 @@
+The Core subteam shepherds technical RFCs through the RFC process, and makes
+technical governance decisions; technical topics include those related to the
+design and architecture of Sawtooth. This team is responsible for ensuring
+long-term architectural consistency with the existing Sawtooth code and overall
+project direction adopted by the Root subteam.
+
+The Core subteam is the default subteam for technical decisions in absence of
+another appropriate subteam.
+
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
+| Andi Gunderson | agunde406 | agunde |
+| Dan Middleton | dcmiddle | Dan |
+| James Mitchell | jsmitchell | jsmitchell |
+| Peter Schwarz | peterschwarz | pschwarz |
+| Shawn Amundson | vaporos | amundson |
+
+The team lead is Shawn Amundson.
+
+RFC PR: [hyperledger/sawtooth-rfcs#24](https://github.com/hyperledger/sawtooth-rfcs/pull/24)

--- a/subteams/root.md
+++ b/subteams/root.md
@@ -1,0 +1,14 @@
+The root team serves as leadership for the Sawtooth project as a whole.
+
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
+| Andi Gunderson | agunde406 | agunde |
+| Dan Middleton | dcmiddle | Dan |
+| James Mitchell | jsmitchell | jsmitchell |
+| Kelly Olson | ineffectualproperty | kelly\_ |
+| Peter Schwarz | peterschwarz | pschwarz |
+| Shawn Amundson | vaporos | amundson |
+| Tom Barnes | TomBarnes | TomBarnes |
+
+RFC PR: [hyperledger/sawtooth-rfcs#6](https://github.com/hyperledger/sawtooth-rfcs/pull/6)

--- a/subteams/sabre.md
+++ b/subteams/sabre.md
@@ -1,0 +1,13 @@
+The Sabre subteam shepherds RFCs through the RFC process and makes governance
+decisions regarding the design and direction of Sawtooth Sabre.
+
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Andi Gunderson | agunde406 | agunde |
+| James Mitchell | jsmitchell | jsmitchell |
+| Shawn Amundson | vaporos | amundson |
+| Ryan Banks | RyanBanks | RyanBanks |
+
+The team lead is Shawn Amundson.
+
+RFC PR: [hyperledger/sawtooth-rfcs#7](https://github.com/hyperledger/sawtooth-rfcs/pull/7)

--- a/subteams/supply_chain.md
+++ b/subteams/supply_chain.md
@@ -1,0 +1,15 @@
+The Supply Chain subteam shepherds RFCs through the RFC process, and makes
+governance decisions regarding the design and direction of Sawtooth Supply
+Chain.
+
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Andi Gunderson | agunde406 | agunde |
+| James Mitchell | jsmitchell | jsmitchell |
+| Kelly Olson | ineffectualproperty | kelly\_ |
+| Shawn Amundson | vaporos | amundson |
+| Zac Delventhal | delventhalz | zac |
+
+The team lead is Shawn Amundson.
+
+RFC PR: [hyperledger/sawtooth-rfcs#11](https://github.com/hyperledger/sawtooth-rfcs/pull/11)


### PR DESCRIPTION
This directory is intended to make it easier to find information
about each subteam, including members, related PRs, etc.
