### PR TITLE
[reopened] Add new peers without restarting a node

### DIFF
--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -107,6 +107,21 @@ message ClientAddPeersResponse {
 The rationale behind the `invalid_uris` is to be more precise about what is
 wrong and to ease the debugging process for developers.
 
+We should also add new message types to `protos/validator.proto`:
+
+```protobuf
+message Message {
+
+    enum MessageType {
+        // ...
+        CLIENT_PEERS_ADD_REQUEST = 131;
+        CLIENT_PEERS_ADD_RESPONSE = 132;
+        // ...
+    }
+    // ...
+}
+```
+
 ## How are the requests processed by the validator
 [request-processing]: #request-processing
 

--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -49,12 +49,12 @@ message ClientAddPeersRequest {
 Simple Python example using `sawtooth_sdk.messaging.stream`:
 
 ```python
-new_peers = ['tcp://192.168.0.100:8008', 'tcp://192.168.0.200:8008']
-add_peers_request = ClientAddPeersRequest(new_peers=new_peers)
-future = stream.send(Message.CLIENT_ADD_PEERS_REQUEST,
-                     add_peers_request.SerializeToString())
+new_peer = 'tcp://192.168.0.100:8008'
+add_peer_request = ClientAddPeerRequest(peer_uri=new_peers)
+future = stream.send(Message.CLIENT_ADD_PEER_REQUEST,
+                     add_peer_request.SerializeToString())
 response_serialized = future.result().content
-response = ClientAddPeersResponse()
+response = ClientAddPeerResponse()
 response.ParseFromString(response_serialized)
 ```
 

--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -133,10 +133,13 @@ message Message {
 ## How are the requests processed by the validator
 [request-processing]: #request-processing
 
-The requests are received on the `component` endpoint. When the validator
-receives a new request for adding peers it:
+The requests are received on the `component` endpoint.
 
-- Validates the format of peer URI which has to be `tcp://ADDRESS:PORT_NUMBER`
+### Adding peers
+
+When the validator receives a new request for adding peers it:
+
+- Validates the format of peer URI which has to be `tcp://ADDRESS:PORT_NUMBER`;
 - If the validation was successful then the validator tries to connect to a
   provided peer. If the connection was successful it returns the `OK` status.
   Otherwise the corresponding error status is returned.
@@ -152,6 +155,15 @@ Edge cases:
   fails with an error if so. The validator also fails if it cannot add _all_ of
   the peers provided in a request without breaking the provided
   `maximum-peer-connectivity`.
+
+### Removing peers
+
+When the validator receives a new request for removing peers it does the
+following:
+
+- Validates the format of peer URI which has to be `tcp://ADDRESS:PORT_NUMBER`;
+- If a peer is connected the validator removes it. Otherwise the
+  `PEER_NOT_FOUND` error is thrown.
 
 ## Permissioning
 

--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -19,7 +19,7 @@ significantly harder to write than if we had the possibility to add peers in the
 runtime and also decreases the uptime.
 
 To resolve this problem our team proposes to add a method to add new peers to a
-running node.
+running node and to remove peers from a running node.
 
 An example use case is using Sawtooth along with a service discovery system like
 [Consul](https://www.consul.io):

--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -4,21 +4,18 @@
 - Sawtooth Issue: (leave this empty)
 
 # Summary
-[summary]: #summary This RFC proposes to implement the possibility to add new
-peers and remove the existing connections in runtime (through the component
-validator endpoint) when a node is working in the `static` peering mode. Along
-with that it also adds the corresponding extensions to the off-chain
-permissioning model.
+[summary]: #summary This RFC proposes functionality to add and remove static
+peer connections while a validator node is running in the `static` peering mode.
+This RFC also adds the corresponding extensions to the off-chain permssioning
+model.
 
 # Motivation
 [motivation]: #motivation
 
-When an administrator adds a new node to an existing Sawtooth network he/she has
-to restart a node with new peering settings. This makes any automation
-significantly harder to write than if we had the possibility to add peers in the
-runtime and also decreases the uptime.
-
-To resolve this problem our team proposes to add a method to add new peers to a
+When an administrator adds a new node to an existing Sawtooth network, he has to
+restart a node with new peering settings. Restarting the process adds
+substantial complexity to infrastructure automation, and incurs system downtime.
+To resolve this problem, our team proposes to add a method to add new peers to a
 running node and to remove peers from a running node.
 
 An example use case is using Sawtooth along with a service discovery system like
@@ -33,10 +30,10 @@ An example use case is using Sawtooth along with a service discovery system like
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-When an administrator adds new peers to the network you very likely want to add
-them without restarting the validator with a newer `--peers` parameter value. To
-add a new peer you can send the `ClientAddPeersRequest` to the `component`
-endpoint of your Sawtooth validator.
+When an administrator adds new peers to the network, he likely wants to connect
+to them without needing to restart existing validators with an updated `--peers`
+parameter value. To add a new peer, the administrator can send send the
+`ClientAddPeersRequest` to the `component` endpoint of your Sawtooth validator.
 
 The Protocol Buffers definition for this message is the following:
 
@@ -64,7 +61,7 @@ response.ParseFromString(response_serialized)
 ## Protocol Buffers definitions
 [protobuf]: #protobuf
 
-I propose to add them to `protos/client_peers.proto`:
+The definitions proposed to be added to `protos/client_peers.proto`:
 
 ```protobuf
 message ClientAddPeerRequest {
@@ -113,7 +110,7 @@ message ClientRemovePeerResponse {
 The rationale behind the `invalid_uris` is to be more precise about what is
 wrong and to ease the debugging process for developers.
 
-We should also add new message types to `protos/validator.proto`:
+New message types should also be added to `protos/validator.proto`:
 
 ```protobuf
 message Message {
@@ -140,18 +137,18 @@ The requests are received on the `component` endpoint.
 When the validator receives a new request for adding peers it:
 
 - Validates the format of peer URI which has to be `tcp://ADDRESS:PORT_NUMBER`;
-- If the validation was successful then the validator tries to connect to a
-  provided peer. If the connection was successful it returns the `OK` status.
-  Otherwise the corresponding error status is returned.
+- If the validation was successful, then the validator tries to connect to a
+  provided peer. If the connection was successful, it returns the `OK` status.
+  Otherwise, the corresponding error status is returned.
 
 Edge cases:
 
 - The peer address format was wrong in one or more of the provided peers. If
-  that happens then the request fails without adding any new peers to the peers
+  that happens, then the request fails without adding any new peers to the peers
   list and returns the `INVALID_PEER_URI` status along with the list of faulty
   peer URIs.
-- If the `--maximum-peer-connectivity` parameter was provided to the validator
-  then the validator checks if it has reached the maximum peer connectivity and
+- If the `--maximum-peer-connectivity` parameter was provided to the validator,
+  then the validator checks if it has reached the maximum peer connectivity, and
   fails with an error if so. The validator also fails if it cannot add _all_ of
   the peers provided in a request without breaking the provided
   `maximum-peer-connectivity`.
@@ -162,7 +159,7 @@ When the validator receives a new request for removing peers it does the
 following:
 
 - Validates the format of peer URI which has to be `tcp://ADDRESS:PORT_NUMBER`;
-- If a peer is connected the validator removes it. Otherwise the
+- If a peer is connected, the validator removes it. Otherwise, the
   `PEER_NOT_FOUND` error is thrown.
 
 ## Permissioning
@@ -171,16 +168,16 @@ The proposition is to add the `admin` role to off-chain permissioning that will
 restrict access to requests that can be malicious. The workflow for the
 validation is the following:
 
-- If the `admin` role is not specified then the permissioning module will use
+- If the `admin` role is not specified, then the permissioning module will use
   the `default` policy.
-- If the `default` policy is not specified then the validation of the
+- If the `default` policy is not specified, then the validation of the
   permissions is not performed and fields `admin_public_key` and `signature` can
   be omitted.
 - If the `default` or the `admin` policy is specified, then the permission
   verifier checks:
   - If the `admin_public_key` is allowed.
   - If the `signature` is correct.
-  - If one of the above conditions is not satisfied then the
+  - If one of the above conditions is not satisfied, then the
     `ADMIN_AUTHORIZATION_ERROR` is returned.
 
 # Drawbacks
@@ -213,9 +210,9 @@ Those two allow adding new peers in their platforms. Interesting points:
   final solution on "should it be included to the REST API or no?"
 - In the same discussion, there was a proposition to resolve security issues by
   using this feature along with the permissioning module. If we do not add this
-  feature to the REST API and hence to the administrative utilities then I do
+  feature to the REST API and hence to the administrative utilities, then I do
   not see any point in permissioning because the described feature remains an
-  internal interface of the application. Even if we do then we can restrict the
+  internal interface of the application. Even if we do, then we can restrict the
   access to that feature by using a proxy as suggested in the documentation.
 - Should our team include the integration example of this solution for Consul?
 - Should the permissioning be left as it is or generalized to a structure like

--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -1,0 +1,173 @@
+- Feature Name: `add_peers_in_runtime`
+- Start Date: 2018-11-12
+- RFC PR: (leave this empty)
+- Sawtooth Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+This RFC proposes to implement the possibility to add new peers in runtime
+(through the component validator endpoint) when a node is working in the
+`static` peering mode. Along with that it also adds the corresponding extensions
+to the off-chain permissioning model.
+
+# Motivation
+[motivation]: #motivation
+
+When an administrator adds a new node to an existing Sawtooth network he/she has
+to restart a node with new peering settings. This makes any automation
+significantly harder to write than if we had the possibility to add peers in the
+runtime and also decreases the uptime.
+
+To resolve this problem our team proposes to add a method to add new peers to a
+running node.
+
+An example use case is using Sawtooth along with a service discovery system like
+[Consul](https://www.consul.io):
+
+- A Consul node is set up along with the Sawtooth node;
+- A middleware continuously fetches the changes of the peer list from the
+  Consul node;
+- The middleware adds peers to the Sawtooth node via the validator component
+  endpoint.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+When an administrator adds new peers to the network you very likely want to
+add them without restarting the validator with a newer `--peers` parameter
+value. To add a new peer you can send the `ClientAddPeersRequest` to the
+`component` endpoint of your Sawtooth validator.
+
+The Protocol Buffers definition for this message is the following:
+
+```protobuf
+message ClientAddPeersRequest {
+    repeated string peers = 1;
+}
+```
+
+Simple Python example using `sawtooth_sdk.messaging.stream`:
+
+```python
+new_peers = ['tcp://192.168.0.100:8008', 'tcp://192.168.0.200:8008']
+add_peers_request = ClientAddPeersRequest(new_peers=new_peers)
+future = stream.send(Message.CLIENT_ADD_PEERS_REQUEST,
+                     add_peers_request.SerializeToString())
+response_serialized = future.result().content
+response = ClientAddPeersResponse()
+response.ParseFromString(response_serialized)
+```
+
+The response Protocol Buffers definition is the following:
+
+```protobuf
+message ClientAddPeersResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        // One or more of peer URIs were malformed. List of malformed URIs is in
+        // the `invalid_uris` field of this response.
+        INVALID_PEER_URI = 3;
+        MAXIMUM_PEERS_CONNECTIVITY_REACHED = 4;
+    }
+    Status status = 1;
+    repeated string invalid_uris = 2;
+}
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+## Protocol Buffers definitions
+[protobuf]: #protobuf
+
+I propose to add them to `protos/client_peers.proto`:
+
+```protobuf
+message ClientAddPeersRequest {
+    repeated string peers = 1;
+}
+
+message ClientAddPeersResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        // One or more of peer URIs were malformed. List of malformed URIs is in
+        // the `invalid_uris` field of this response.
+        INVALID_PEER_URI = 3;
+        MAXIMUM_PEERS_CONNECTIVITY_REACHED = 4;
+    }
+    Status status = 1;
+    repeated string invalid_uris = 2;
+}
+```
+
+The rationale behind the `invalid_uris` is to be more precise about what is
+wrong and to ease the debugging process for developers.
+
+## How are the requests processed by the validator
+[request-processing]: #request-processing
+
+The requests are received on the `component` endpoint. When the validator
+receives a new request for adding peers it:
+
+- Validates the format of peer URIs which has to be
+  `tcp://IP_ADDRESS:PORT_NUMBER`
+- If the validation was successful then the validator updates its peer list and
+  immediately returns the `OK` response. The new peers are connected _after_
+  that.
+
+Edge cases:
+
+- The peer address format was wrong in one or more of the provided peers. If
+  that happens then the request fails without adding any new peers to the peers
+  list and returns the `INVALID_PEER_URI` status along with the list of faulty
+  peer URIs.
+- If the `--maximum-peer-connectivity` parameter was provided to the validator
+  then the validator checks if it has reached the maximum peer connectivity and
+  fails with an error if so. The validator also fails if it cannot add _all_ of
+  the peers provided in a request without breaking the provided
+  `maximum-peer-connectivity`.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- The proposed solution does not provide any information on the status of new
+  peers. It just returns immediately if a request does not break the conditions
+  specified in the previous chapter.
+- It does not specify any connection retry policies leaving it to the existing
+  peering implementation.
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+Alternatives were not considered and judging from multiple examples this is the
+state-of-the-art solution.
+
+# Prior art
+[prior-art]: #prior-art
+
+- [`addnode` in Bitcoin JSON RPC](https://bitcoincore.org/en/doc/0.16.0/rpc/network/addnode/)
+- [`admin_addPeer` in Ethereum management API](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#admin_addpeer)
+
+Those two allow adding new peers in their platforms. Interesting points:
+
+- Ethereum can return the connection status;
+- Bitcoin allows specifying the connection retry policy.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- During the pre-RFC discussion on the #sawtooth-core-dev channel, there was no
+  final solution on "should it be included to the REST API or no?"
+- In the same discussion, there was a proposition to resolve security issues by
+  using this feature along with the permissioning module. If we do not add this
+  feature to the REST API and hence to the administrative utilities then I do
+  not see any point in permissioning because the described feature remains an
+  internal interface of the application. Even if we do then we can restrict the
+  access to that feature by using a proxy as suggested in the documentation.
+- Should the system notify its user about the statuses of new connections or
+  leave the status check to the end user?
+- Should our team include the integration example of this solution for Consul?

--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -195,8 +195,8 @@ state-of-the-art solution.
 # Prior art
 [prior-art]: #prior-art
 
-- [`addnode` in Bitcoin JSON RPC](https://bitcoincore.org/en/doc/0.16.0/rpc/network/addnode/)
-- [`admin_addPeer` in Ethereum management API](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#admin_addpeer)
+- [`addnode` in Bitcoin JSON RPC][btcrpc]
+- [`admin_addPeer` in Ethereum management API][ethrpc]
 
 Those two allow adding new peers in their platforms. Interesting points:
 
@@ -217,3 +217,6 @@ Those two allow adding new peers in their platforms. Interesting points:
 - Should our team include the integration example of this solution for Consul?
 - Should the permissioning be left as it is or generalized to a structure like
   `(admin_public_key, signature, request)`?
+
+[btcrpc]: https://bitcoincore.org/en/doc/0.16.0/rpc/network/addnode/
+[ethrpc]: https://github.com/ethereum/go-ethereum/wiki/Management-APIs#admin_addpeer

--- a/text/0000-add-peers-in-runtime.md
+++ b/text/0000-add-peers-in-runtime.md
@@ -122,8 +122,8 @@ message Message {
         // ...
         CLIENT_PEERS_ADD_REQUEST = 131;
         CLIENT_PEERS_ADD_RESPONSE = 132;
-        CLIENT_PEERS_REMOVE_REQUEST = 131;
-        CLIENT_PEERS_REMOVE_RESPONSE = 132;
+        CLIENT_PEERS_REMOVE_REQUEST = 133;
+        CLIENT_PEERS_REMOVE_RESPONSE = 134;
         // ...
     }
     // ...


### PR DESCRIPTION
This pull request is created instead of #32, because my access to the previous fork have been revoked.

Changes made since the last commit to #32:

* Introduced the `admin` endpoint as discussed with @jsmitchell; 
* Modified older messages to live inside the `admin` endpoint.