### PR TITLE
Fix Swift SDK RFC 0037 Numbering

### DIFF
--- a/text/0037-sawtooth-sdk-swift.md
+++ b/text/0037-sawtooth-sdk-swift.md
@@ -1,6 +1,6 @@
 - Feature Name: sawtooth_sdk_swift
 - Start Date: 2019-02-14
-- RFC PR:
+- RFC PR: https://github.com/hyperledger/sawtooth-rfcs/pull/37
 - Sawtooth Issue:
 
 # Summary


### PR DESCRIPTION
The Swift SDK RFC is 0037, not 0000.

Signed-off-by: danintel <daniel.anderson@intel.com>