### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,14 @@
+**Active maintainers**
 | Name | GitHub |
 | --- | --- |
 | Andi Gunderson | agunde406 |
 | Dan Middleton | dcmiddle |
-| James Mitchell | jsmitchell |
-| Kelly Olson | ineffectualproperty |
 | Peter Schwarz | peterschwarz |
 | Shawn Amundson | vaporos |
+
+**Emeritus maintainers**
+| Name | GitHub |
+| --- | --- |
 | Tom Barnes | TomBarnes |
+| James Mitchell | jsmitchell |
+| Kelly Olson | ineffectualproperty |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>